### PR TITLE
Add sorting freeze hotkey

### DIFF
--- a/doc/nethogs.8
+++ b/doc/nethogs.8
@@ -101,6 +101,9 @@ display the program basename
 .TP
 m
 switch between total (KB, B, MB) and throughput (KB/s, MB/s, GB/s) mode
+.TP
+o
+toggle sorting on/off
 .RE
 
 .SH "RUNNING WITHOUT ROOT"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,6 +69,7 @@ static void help(bool iserror) {
   output << " b: display the program basename instead of the fullpath\n";
   output << " m: switch between total (kB, bytes, MB) and throughput (kB/s, "
             " MB/s, GB/s) mode\n";
+  output << " o: toggle sorting on/off\n";
 }
 
 void quit_cb(int /* i */) {

--- a/src/nethogs.cpp
+++ b/src/nethogs.cpp
@@ -31,6 +31,7 @@
 #include <getopt.h>
 #include <iostream>
 #include <string>
+#include <vector>
 #include <unistd.h>
 
 #include <netinet/ip.h>
@@ -61,6 +62,9 @@ bool bughuntmode = false;
 bool sortRecv = true;
 bool showcommandline = false;
 bool showBasename = false;
+bool freezeSorting = false;
+std::vector<pid_t> frozenPids;
+std::vector<pid_t> lastSortedPids;
 // viewMode: kb/s or total
 int viewMode = VIEWMODE_KBPS;
 const char version[] = " version " VERSION;

--- a/src/nethogs.h
+++ b/src/nethogs.h
@@ -37,6 +37,7 @@
 #include <malloc.h>
 #endif
 #include <iostream>
+#include <vector>
 
 #define _BSD_SOURCE 1
 
@@ -110,5 +111,9 @@ private:
 void quit_cb(int i);
 
 const char *getVersion();
+
+extern bool freezeSorting;
+extern std::vector<pid_t> frozenPids;
+extern std::vector<pid_t> lastSortedPids;
 
 #endif


### PR DESCRIPTION
## Summary
- add new interactive command `o` to toggle sorting freeze
- keep pid order stable when sorting freeze is active
- document the new hotkey in `main.cpp` help and man page
